### PR TITLE
Surface real Airflow errors and fix list_recent_failures filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.0] - 2026-05-27
+
+### Fixed
+- `_invoke_airflow_api` now surfaces the underlying Airflow HTTP status code and response body when MWAA returns `RestApiClientException` / `RestApiServerException`. Previously these came back as `{"error": "An error occurred (RestApiClientException) ... : "}` with no diagnostic information — callers couldn't tell a 404 (endpoint missing/renamed in Airflow 3.x) from a 422 (bad param) from a 5xx. Errors now also include `error_code`, `rest_api_status_code`, and `rest_api_response` fields.
+- `list_recent_failures` (task-instance mode) now actually returns recent failures. Airflow's batch task-instances endpoint silently ignores `start_date_gte` and defaults to oldest-first ordering, so the previous implementation returned months-old failures in response to a `days=3` query. Now applies the date filter and newest-first sort client-side, with the cutoff exposed in the summary as `client_filtered_cutoff` / `client_filtered_count` / `client_sorted`.
+- `summarize_task_failure` docstring no longer advertises framework-specific output keys that the implementation never produced. The documented `Returns:` shape now matches what `LogSummary.to_dict()` actually emits.
+
+### Added
+- 4 new tests covering the boto error-surfacing path and the client-side filter/sort in `list_recent_failures` (both task-instance and dag-id branches).
+
 ## [0.1.0] - 2026-03-06
 
 ### Changed

--- a/awslabs/mwaa_mcp_server/__init__.py
+++ b/awslabs/mwaa_mcp_server/__init__.py
@@ -4,4 +4,4 @@ from .server import mcp
 from .tools import MWAATools
 
 __all__ = ["mcp", "MWAATools"]
-__version__ = "0.1.0"
+__version__ = "0.2.0"

--- a/awslabs/mwaa_mcp_server/log_summary.py
+++ b/awslabs/mwaa_mcp_server/log_summary.py
@@ -7,9 +7,6 @@ rather than the whole 50KB blob.
 
 The patterns here are intentionally framework-agnostic: Python tracebacks,
 Python exceptions, Airflow's task-failure markers, and non-zero exit codes.
-Anyone running domain-specific frameworks on Airflow (dbt, Spark, Beam, ML
-pipelines, etc.) can extend this by passing additional matchers — see the
-docstring on ``summarize_log``.
 """
 
 from __future__ import annotations

--- a/awslabs/mwaa_mcp_server/server.py
+++ b/awslabs/mwaa_mcp_server/server.py
@@ -595,8 +595,8 @@ async def summarize_task_failure(
     """Extract just the failure-relevant lines from a task instance's log.
 
     Replaces the "get_task_logs → grep for FAIL/Exception" pattern. Pulls the
-    full log, runs heuristics for dbt FAIL/ERROR, Python tracebacks/exceptions,
-    Airflow task-failed markers, and non-zero exit codes, and returns matched
+    full log, runs framework-agnostic heuristics (Python tracebacks/exceptions,
+    Airflow task-failed markers, non-zero exit codes), and returns matched
     lines with surrounding context plus a headline synopsis.
 
     Use this for triage. Use ``get_task_logs`` only if you need the raw text.
@@ -610,7 +610,8 @@ async def summarize_task_failure(
         context_lines: Lines of context before/after each match (default 4)
 
     Returns:
-        {summary, headline, dbt_test_failures, python_exceptions, ..., resource_uri}
+        ``{summary, headline, python_exceptions, python_tracebacks,
+        airflow_task_failures, non_zero_exits, total_lines, resource_uri}``
     """
     return await tools.summarize_task_failure(
         environment_name,

--- a/awslabs/mwaa_mcp_server/tools.py
+++ b/awslabs/mwaa_mcp_server/tools.py
@@ -138,6 +138,29 @@ class MWAATools:
             response = self.mwaa_client.invoke_rest_api(**params)
             return response
 
+        except ClientError as e:
+            # MWAA's RestApiClientException / RestApiServerException are
+            # ClientError subclasses. The boto wrapper's str() is often empty
+            # (e.g. "An error occurred (RestApiClientException) ... : ").
+            # The actual diagnostic info lives in e.response — surface the
+            # HTTP status code from Airflow and any response body so callers
+            # can see what really failed (404 for a removed endpoint, 422 for
+            # a bad param, etc.) instead of getting an opaque empty error.
+            err_info = e.response.get("Error") or {}
+            err_code = err_info.get("Code")
+            err_msg = err_info.get("Message") or ""
+            rest_status = e.response.get("RestApiStatusCode")
+            rest_body = e.response.get("RestApiResponse")
+            logger.error(
+                "Error invoking Airflow API %s %s: code=%s msg=%s status=%s body=%s",
+                method, path, err_code, err_msg, rest_status, rest_body,
+            )
+            return {
+                "error": err_msg or str(e),
+                "error_code": err_code,
+                "rest_api_status_code": rest_status,
+                "rest_api_response": rest_body,
+            }
         except Exception as e:
             logger.error("Error invoking Airflow API %s %s: %s", method, path, e)
             return {"error": str(e)}
@@ -710,7 +733,7 @@ class MWAATools:
         ti_states = ["failed"]
         if include_upstream_failed:
             ti_states.append("upstream_failed")
-        return await self.list_task_instances(
+        result = await self.list_task_instances(
             environment_name=environment_name,
             start_date_gte=cutoff,
             state=ti_states,
@@ -718,6 +741,25 @@ class MWAATools:
             page=1,
             page_size=min(limit, DEFAULT_PAGE_SIZE),
         )
+        if "error" in result:
+            return result
+
+        # Airflow's batch task-instances endpoint silently ignores
+        # ``start_date_gte`` and defaults to oldest-first ordering. Without
+        # client-side handling, the "most recent failures in the last N days"
+        # contract is broken — callers got months-old failures instead of
+        # the recent ones they asked for. Filter + sort here so the surface
+        # behavior matches the docstring.
+        tis = result.get("task_instances", []) or []
+        tis = [t for t in tis if (t.get("start_date") or "") >= cutoff]
+        tis.sort(key=lambda t: t.get("start_date") or "", reverse=True)
+        result["task_instances"] = tis
+        summary = result.get("summary") or {}
+        summary["client_filtered_cutoff"] = cutoff
+        summary["client_filtered_count"] = len(tis)
+        summary["client_sorted"] = "start_date desc"
+        result["summary"] = summary
+        return result
 
     async def summarize_task_failure(
         self,
@@ -730,16 +772,19 @@ class MWAATools:
     ) -> Dict[str, Any]:
         """Fetch a task's log and return the lines that explain the failure.
 
-        Runs heuristic matchers for dbt FAIL/ERROR/Runtime Error, Python
-        tracebacks/exceptions, Airflow "Task failed" markers, and non-zero
-        exit codes. Returns:
+        Runs framework-agnostic heuristic matchers (Python tracebacks/
+        exceptions, Airflow "Task failed" markers, non-zero exit codes) and
+        returns matched lines with surrounding context plus a headline
+        synopsis. Returns:
 
             {
-              "headline": "...",            # one-line synopsis
-              "dbt_done_stats": {...},      # if dbt ran a build
-              "dbt_test_failures": [...],   # each with line_no + context
-              "python_exceptions": [...],
-              ...
+              "summary": {...},                   # echo of the request args
+              "headline": "...",                  # one-line synopsis
+              "python_exceptions": [...],         # each with line_no + context
+              "python_tracebacks": [...],
+              "airflow_task_failures": [...],
+              "non_zero_exits": [...],
+              "total_lines": int,
               "resource_uri": "mwaa://logs/...",  # full log if needed
             }
         """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "awslabs.mwaa-mcp-server"
-version = "0.1.0"
+version = "0.2.0"
 description = "AWS MWAA MCP Server for managing Amazon Managed Workflows for Apache Airflow environments and Airflow operations"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,6 +1,7 @@
 """Tests for MWAA MCP Server."""
 
 import pytest
+from botocore.exceptions import ClientError
 from unittest.mock import Mock, patch
 
 from awslabs.mwaa_mcp_server.tools import MWAATools
@@ -284,3 +285,175 @@ class TestAirflowApiTools:
 
         call_args = mock_boto_client.invoke_rest_api.call_args
         assert "/dags/importErrors" in call_args.kwargs["Path"]
+
+
+class TestAirflowApiErrorSurfacing:
+    """When the underlying Airflow REST call fails, callers should see what
+    really happened — status code and response body — not an opaque empty
+    ``RestApiClientException``.
+    """
+
+    @pytest.mark.asyncio
+    async def test_client_error_surfaces_status_and_body(
+        self, mwaa_tools, mock_boto_client
+    ):
+        # Simulate MWAA raising RestApiClientException with the Airflow body
+        # tucked into the response payload. boto exposes it via e.response.
+        airflow_body = {"detail": "DAG with dag_id: foo was not found"}
+        err = ClientError(
+            error_response={
+                "Error": {
+                    "Code": "RestApiClientException",
+                    "Message": "",
+                },
+                "RestApiStatusCode": 404,
+                "RestApiResponse": airflow_body,
+            },
+            operation_name="InvokeRestApi",
+        )
+        mock_boto_client.invoke_rest_api.side_effect = err
+
+        result = await mwaa_tools.get_dag("test-env", "missing-dag")
+
+        # Previously this returned only {"error": "<empty boto wrapper text>"}
+        # which was useless for diagnosis. Now the real Airflow status code
+        # and body should be reachable.
+        assert result.get("error_code") == "RestApiClientException"
+        assert result.get("rest_api_status_code") == 404
+        assert result.get("rest_api_response") == airflow_body
+
+    @pytest.mark.asyncio
+    async def test_client_error_with_empty_message_still_has_status(
+        self, mwaa_tools, mock_boto_client
+    ):
+        # The original opaque-error case: empty Message, no body. The status
+        # code is still informative, so callers can at least tell 4xx vs 5xx.
+        err = ClientError(
+            error_response={
+                "Error": {"Code": "RestApiClientException", "Message": ""},
+                "RestApiStatusCode": 422,
+            },
+            operation_name="InvokeRestApi",
+        )
+        mock_boto_client.invoke_rest_api.side_effect = err
+
+        result = await mwaa_tools.get_dag_source("test-env", "some-dag")
+        assert result.get("rest_api_status_code") == 422
+        assert result.get("error_code") == "RestApiClientException"
+
+
+class TestListRecentFailures:
+    """list_recent_failures must actually return *recent* failures.
+
+    Airflow's batch task-instances endpoint silently ignores ``start_date_gte``
+    and orders oldest-first, so we have to filter and sort client-side. The
+    regression these tests guard against: returning months-old failures when
+    the caller asked for the last 3 days.
+    """
+
+    @pytest.mark.asyncio
+    async def test_task_instance_mode_filters_old_failures(
+        self, mwaa_tools, mock_boto_client
+    ):
+        # Mix of old (Feb) and recent (within lookback) task instances.
+        # The Feb ones should be filtered out; the recent ones should be
+        # ordered newest-first.
+        mock_boto_client.invoke_rest_api.return_value = {
+            "RestApiResponse": {
+                "task_instances": [
+                    {
+                        "task_id": "ancient_task",
+                        "dag_id": "old_dag",
+                        "dag_run_id": "scheduled__2026-02-22T00:35:00+00:00",
+                        "start_date": "2026-02-22T00:55:31Z",
+                        "state": "failed",
+                    },
+                    {
+                        "task_id": "recent_task_old",
+                        "dag_id": "x",
+                        "dag_run_id": "scheduled__2026-05-25T00:00:00+00:00",
+                        "start_date": "2026-05-25T01:00:00Z",
+                        "state": "failed",
+                    },
+                    {
+                        "task_id": "recent_task_new",
+                        "dag_id": "x",
+                        "dag_run_id": "scheduled__2026-05-27T00:00:00+00:00",
+                        "start_date": "2026-05-27T01:00:00Z",
+                        "state": "failed",
+                    },
+                ],
+                "total_entries": 3,
+            },
+            "RestApiStatusCode": 200,
+        }
+
+        # Freeze "now" so the cutoff (now - days) is deterministic.
+        import datetime as _dt
+
+        class _FixedDT(_dt.datetime):
+            @classmethod
+            def now(cls, tz=None):
+                return _dt.datetime(2026, 5, 27, 12, 0, 0, tzinfo=tz)
+
+        with patch("awslabs.mwaa_mcp_server.tools.datetime", _FixedDT):
+            result = await mwaa_tools.list_recent_failures(
+                environment_name="test-env",
+                days=3,  # cutoff = 2026-05-24T12:00:00Z
+            )
+
+        tis = result.get("task_instances") or []
+        ids = [t["task_id"] for t in tis]
+        # Ancient task must be filtered out
+        assert "ancient_task" not in ids
+        # Both recent ones must be present, newest first
+        assert ids == ["recent_task_new", "recent_task_old"]
+        # Summary should expose what we did
+        summary = result.get("summary", {})
+        assert summary.get("client_filtered_count") == 2
+        assert summary.get("client_sorted") == "start_date desc"
+
+    @pytest.mark.asyncio
+    async def test_dag_id_mode_filters_old_failures(
+        self, mwaa_tools, mock_boto_client
+    ):
+        # When dag_id is passed we use the dag_runs endpoint; same kind of
+        # client-side filter applies. Existing code already had it for this
+        # branch — this test guards against future regressions.
+        mock_boto_client.invoke_rest_api.return_value = {
+            "RestApiResponse": {
+                "dag_runs": [
+                    {
+                        "dag_run_id": "scheduled__2026-02-22T00:35:00+00:00",
+                        "start_date": "2026-02-22T00:55:31Z",
+                        "state": "failed",
+                    },
+                    {
+                        "dag_run_id": "scheduled__2026-05-26T00:00:00+00:00",
+                        "start_date": "2026-05-26T01:00:00Z",
+                        "state": "failed",
+                    },
+                ],
+                "total_entries": 2,
+            },
+            "RestApiStatusCode": 200,
+        }
+
+        import datetime as _dt
+
+        class _FixedDT(_dt.datetime):
+            @classmethod
+            def now(cls, tz=None):
+                return _dt.datetime(2026, 5, 27, 12, 0, 0, tzinfo=tz)
+
+        with patch("awslabs.mwaa_mcp_server.tools.datetime", _FixedDT):
+            result = await mwaa_tools.list_recent_failures(
+                environment_name="test-env",
+                dag_id="my_dag",
+                days=3,
+            )
+
+        runs = result.get("dag_runs") or []
+        ids = [r["dag_run_id"] for r in runs]
+        assert "scheduled__2026-02-22T00:35:00+00:00" not in ids
+        assert "scheduled__2026-05-26T00:00:00+00:00" in ids


### PR DESCRIPTION
## Summary

Two diagnostic fixes against the tools added in `d89db80` (PR #2), plus a small docstring-drift cleanup. All MWAA-level, no framework assumptions.

| # | Tool | Symptom |
|---|---|---|
| 1 | `get_dag_source`, `get_import_errors`, `summarize_task_failure` (no `task_try_number`) | Returned `{"error": "An error occurred (RestApiClientException) ... : "}` — empty after the colon. No way to diagnose. |
| 2 | `list_recent_failures` (task-instance mode, no `dag_id`) | Asked for `days=3`, got back failures from three *months* ago. |

## What changed

### 1. `_invoke_airflow_api` — surface the real error (`tools.py`)

MWAA's `invoke_rest_api` raises `RestApiClientException` / `RestApiServerException` (both `ClientError` subclasses). The actual diagnostic info — the Airflow HTTP status code and response body — lives in `e.response`, not in `str(e)`. The boto wrapper's `str()` is often empty.

Catch `ClientError` explicitly and return:

```python
{
    "error": err_msg or str(e),
    "error_code": err_code,                # e.g. "RestApiClientException"
    "rest_api_status_code": rest_status,   # e.g. 404, 422
    "rest_api_response": rest_body,        # Airflow's response body
}
```

Once this lands, the next investigation step on the still-failing tools (`get_dag_source` at `/dags/{id}/dagSource`, `get_import_errors` at `/dags/importErrors`) becomes possible — we'll actually see what Airflow is saying.

### 2. `list_recent_failures` task-instance branch (`tools.py`)

The `dag_id` branch already had a client-side filter for the same reason; this aligns the task-instance branch. After the underlying `list_task_instances` call:

```python
tis = [t for t in tis if (t.get("start_date") or "") >= cutoff]
tis.sort(key=lambda t: t.get("start_date") or "", reverse=True)
```

…and exposes `client_filtered_cutoff`, `client_filtered_count`, `client_sorted` on the summary.

### 3. `summarize_task_failure` docstring drift (`server.py`, `tools.py`)

The docstrings in PR #2 advertised output keys that the implementation never produced. The documented `Returns:` shape now matches what `LogSummary.to_dict()` actually emits.

## Tests

4 new tests, all passing alongside the existing 27 (31 total):

- `test_client_error_surfaces_status_and_body` — guards against the opaque-error regression
- `test_client_error_with_empty_message_still_has_status` — even when Airflow returns no body, the status code makes it through
- `test_task_instance_mode_filters_old_failures` — Feb failures get filtered, recent ones returned newest-first
- `test_dag_id_mode_filters_old_failures` — same guarantee for the dag_id branch

```
============================== 31 passed in 3.54s ==============================
```

## Out of scope (separate follow-ups)

- `get_dag_source` (`/dags/{dag_id}/dagSource`) and `get_import_errors` (`/dags/importErrors`) likely have Airflow 3.0 endpoint changes — but until the error-surfacing fix lands we can't see the actual error. Defer.
- `get_dag_run_heatmap` returns 75KB for 322 cells (full `dag_run_id` etc. per cell). Could benefit from a `compact=true` matrix-only mode.
- Several tools return raw boto envelopes (`ResponseMetadata`, `RestApiStatusCode`, `RestApiResponse` wrappers) instead of unwrapping to just the Airflow payload. Cosmetic cleanup.
- Docstring tweak for `list_connections` / `list_variables` to note they only see the Airflow metadata DB and will be empty on MWAA envs using SSM/Secrets-Manager backends (a common setup, including this env).

🤖 Generated with [Claude Code](https://claude.com/claude-code)