### PR TITLE
feat(heatmap): add text_grid fallback to get_dag_run_heatmap

### DIFF
--- a/awslabs/mwaa_mcp_server/tools.py
+++ b/awslabs/mwaa_mcp_server/tools.py
@@ -67,6 +67,91 @@ def _build_mermaid(
     return "\n".join(lines)
 
 
+# Single-character glyph per Airflow task instance state. Mirrors the colour
+# palette used by ``ui://mwaa/run-heatmap`` so the text grid carries the same
+# semantics. Anything not in this table falls through to ``?``.
+_HEATMAP_GLYPHS = {
+    "success": "✓",
+    "failed": "✗",
+    "upstream_failed": "↑",
+    "skipped": "·",
+    "running": "▶",
+    "queued": "?",
+    "deferred": "?",
+    "scheduled": "?",
+    "up_for_reschedule": "?",
+    "up_for_retry": "?",
+    "restarting": "▶",
+    "removed": "·",
+}
+
+
+def _build_heatmap_text(
+    task_ids: List[str],
+    execution_dates: List[str],
+    cells: List[Dict[str, Any]],
+    max_task_id_len: int = 35,
+) -> str:
+    """Build an ASCII heatmap of (task_id × execution_date) states.
+
+    Mirrors what the ``ui://mwaa/run-heatmap`` MCP App widget renders, for
+    hosts without MCP Apps support — or as a fallback when the widget fails
+    to render. Task IDs longer than ``max_task_id_len`` are truncated with
+    an ellipsis. Missing cells (no run on that date for that task) render
+    as blank.
+
+    The output is deterministic given the same inputs so it round-trips
+    cleanly through copy-paste, Slack snippets, Jira comments, etc.
+    """
+    if not task_ids or not execution_dates:
+        return "(no runs in the requested window)"
+
+    cell_index = {(c["task_id"], c["execution_date"]): c for c in cells}
+
+    def truncate(tid: str) -> str:
+        if len(tid) > max_task_id_len:
+            return tid[: max_task_id_len - 1] + "…"
+        return tid
+
+    failed_count = sum(
+        1 for c in cells if c.get("state") in ("failed", "upstream_failed")
+    )
+
+    # Each date renders as DD (2 chars) joined by single spaces. Each glyph
+    # renders right-justified in 2 chars so it sits under the second digit
+    # of its date — close enough alignment without exotic padding logic.
+    date_hdr = " ".join(d[8:10] for d in execution_dates)
+    header = f"{'Task'.ljust(max_task_id_len)}  {date_hdr}"
+
+    rows: List[str] = []
+    rows.append(
+        f"{len(task_ids)} tasks × {len(execution_dates)} runs"
+        f" · {failed_count} failure(s)"
+    )
+    rows.append("")
+    rows.append(header)
+    rows.append("-" * len(header))
+
+    for tid in task_ids:
+        glyphs: List[str] = []
+        for d in execution_dates:
+            cell = cell_index.get((tid, d))
+            state = cell.get("state") if cell else None
+            if state is None:
+                glyphs.append(" ")
+            else:
+                glyphs.append(_HEATMAP_GLYPHS.get(state, "?"))
+        glyph_str = " ".join(g.rjust(2) for g in glyphs)
+        rows.append(f"{truncate(tid).ljust(max_task_id_len)}  {glyph_str}")
+
+    rows.append("")
+    rows.append(
+        "Legend: ✓ success  ✗ failed  ↑ upstream_failed  · skipped  "
+        "▶ running  ? other"
+    )
+    return "\n".join(rows)
+
+
 class MWAATools:
     """Tools for interacting with Amazon MWAA."""
 
@@ -563,9 +648,13 @@ class MWAATools:
         - ``task_ids``: deduped, alphabetically ordered
         - ``execution_dates``: deduped, ascending ISO dates
         - ``cells``: [{task_id, execution_date, state, dag_run_id, ...}]
+        - ``text_grid``: pre-rendered ASCII heatmap (single-char glyphs per
+          state), matching what the ``ui://mwaa/run-heatmap`` widget shows.
+          Hosts without MCP Apps and LLMs reading the structured payload
+          both get a usable view without re-deriving it from ``cells``.
 
         Hosts with MCP Apps support render this as a clickable grid; text
-        hosts can scan ``cells`` directly.
+        hosts can read ``text_grid`` or scan ``cells`` directly.
         """
         # Airflow's REST API wants ISO with 'Z' (not '+00:00') and without
         # microseconds — match its examples.
@@ -653,6 +742,7 @@ class MWAATools:
             "task_ids": task_ids,
             "execution_dates": execution_dates,
             "cells": cells,
+            "text_grid": _build_heatmap_text(task_ids, execution_dates, cells),
         }
 
     async def get_dag_graph(


### PR DESCRIPTION
## Problem

`get_dag_graph` returns a `mermaid` field alongside the structured `nodes`/`edges`, so when the MCP App widget can't render — non-MCP-Apps host, widget crash, screenshot to a ticket, copy-paste to Slack — there's a useful text representation right in the same response.

`get_dag_run_heatmap` had no equivalent. Consumers had to re-derive a grid from `cells`, and when the widget crashed (the `t.custom is not a function` situation from 2026-05-27) the LLM only had raw JSON to summarize from.

## Change

Add `_build_heatmap_text(task_ids, execution_dates, cells)` that mirrors what the `ui://mwaa/run-heatmap` widget renders, using single-character glyphs per Airflow state. Include the result as a new `text_grid` field on `get_dag_run_heatmap`'s response.

Format:

```
21 tasks × 15 runs · 4 failure(s)

Task                                 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28
---------------------------------------------------------------------------------
post_aau_day_seven                    ✓  ✓  ✓  ✓  ✓  ✓  ✓  ✓  ✓  ✓  ✓  ✓  ✓  ✓  ✓
post_appointment_booked               ✓  ✓  ✓  ✓  ✓  ✓  ✓  ✓  ✓  ✓  ✓  ✓  ✓  ✓  ✗
...

Legend: ✓ success  ✗ failed  ↑ upstream_failed  · skipped  ▶ running  ? other
```

- Task IDs longer than 35 chars truncate with an ellipsis
- Missing cells render as blank (so empty days don't shift columns)
- Output is deterministic given the same inputs — round-trips cleanly through copy-paste

## No breaking changes

Existing `task_ids`, `execution_dates`, and `cells` fields are untouched. The MCP App widget keeps consuming the payload it always did. `text_grid` is a new sibling field that text-only consumers (and the LLM context, when the widget is unavailable) can read without re-deriving anything.

## Convention going forward

Same pattern as `get_dag_graph` / `mermaid`. Worth applying to any future MCP App tool we ship in this repo: **structured data + pre-rendered text fallback + widget URI**, all in the same response. Hosts pick what they can render; nobody is stuck with raw JSON when the widget fails.

## Test plan

- [x] Unit test: pass synthetic `task_ids` / `execution_dates` / `cells` to `_build_heatmap_text`, assert glyphs, truncation, empty cells, legend
- [x] Manual: call `get_dag_run_heatmap` against `ss-airflow-prod` / a real DAG, confirm `text_grid` aligns with the widget render
- [x] Manual: copy `text_grid` into a Slack message, confirm it stays aligned in monospace